### PR TITLE
[feat] 일반 유저 oauth 로그인 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-router-dom": "^7.9.1",
-        "slick-carousel": "^1.8.1"
+        "slick-carousel": "^1.8.1",
+        "zustand": "^5.0.8"
       },
       "devDependencies": {
         "@eslint/js": "^9.36.0",
@@ -951,7 +952,7 @@
       "version": "19.1.13",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.13.tgz",
       "integrity": "sha512-hHkbU/eoO3EG5/MZkuFSKmYqPbSVk5byPFa3e7y/8TybHiLMACgI8seVYlicwk7H5K/rI2px9xrQp/C+AUDTiQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -1069,9 +1070,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.6",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.6.tgz",
-      "integrity": "sha512-wrH5NNqren/QMtKUEEJf7z86YjfqW/2uw3IL3/xpqZUC95SSVIFXYQeeGjL6FT/X68IROu6RMehZQS5foy2BXw==",
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.7.tgz",
+      "integrity": "sha512-bxxN2M3a4d1CRoQC//IqsR5XrLh0IJ8TCv2x6Y9N0nckNz/rTjZB3//GGscZziZOxmjP55rzxg/ze7usFI9FqQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1134,9 +1135,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001743",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001743.tgz",
-      "integrity": "sha512-e6Ojr7RV14Un7dz6ASD0aZDmQPT/A+eZU+nuTNfjqmRrmkmQlnTNWH0SKmqagx9PeW87UVqapSurtAXifmtdmw==",
+      "version": "1.0.30001745",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001745.tgz",
+      "integrity": "sha512-ywt6i8FzvdgrrrGbr1jZVObnVv6adj+0if2/omv9cmR2oiZs30zL4DIyaptKcbOrBdOIc74QTMoJvSE2QHh5UQ==",
       "dev": true,
       "funding": [
         {
@@ -1233,7 +1234,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -1262,9 +1263,9 @@
       "license": "MIT"
     },
     "node_modules/detect-libc": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.0.tgz",
-      "integrity": "sha512-vEtk+OcP7VBRtQZ1EJ3bdgzSfBjgnEalLTp5zjJrS+2Z1w2KZly4SBdac/WDU3hhsNAZ9E8SC96ME4Ey8MZ7cg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.1.tgz",
+      "integrity": "sha512-ecqj/sy1jcK1uWrwpR67UhYrIFQ+5WlGxth34WquCbamhFA6hkkwiu37o6J5xCHdo1oixJRfVRw+ywV+Hq/0Aw==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1272,9 +1273,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.223",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.223.tgz",
-      "integrity": "sha512-qKm55ic6nbEmagFlTFczML33rF90aU+WtrJ9MdTCThrcvDNdUHN4p6QfVN78U06ZmguqXIyMPyYhw2TrbDUwPQ==",
+      "version": "1.5.224",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.224.tgz",
+      "integrity": "sha512-kWAoUu/bwzvnhpdZSIc6KUyvkI1rbRXMT0Eq8pKReyOyaPZcctMli+EgvcN1PAvwVc7Tdo4Fxi2PsLNDU05mdg==",
       "dev": true,
       "license": "ISC"
     },
@@ -1376,9 +1377,9 @@
       }
     },
     "node_modules/eslint-plugin-react-refresh": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.21.tgz",
-      "integrity": "sha512-MWDWTtNC4voTcWDxXbdmBNe8b/TxfxRFUL6hXgKWJjN9c1AagYEmpiFWBWzDw+5H3SulWUe1pJKTnoSdmk88UA==",
+      "version": "0.4.22",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.22.tgz",
+      "integrity": "sha512-atkAG6QaJMGoTLc4MDAP+rqZcfwQuTIh2IqHWFLy2TEjxr0MOK+5BSG4RzL2564AAPpZkDRsZXAUz68kjnU6Ug==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -2312,9 +2313,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.9.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.9.1.tgz",
-      "integrity": "sha512-pfAByjcTpX55mqSDGwGnY9vDCpxqBLASg0BMNAuMmpSGESo/TaOUG6BllhAtAkCGx8Rnohik/XtaqiYUJtgW2g==",
+      "version": "7.9.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.9.2.tgz",
+      "integrity": "sha512-i2TPp4dgaqrOqiRGLZmqh2WXmbdFknUyiCRmSKs0hf6fWXkTKg5h56b+9F22NbGRAMxjYfqQnpi63egzD2SuZA==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -2334,12 +2335,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.9.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.9.1.tgz",
-      "integrity": "sha512-U9WBQssBE9B1vmRjo9qTM7YRzfZ3lUxESIZnsf4VjR/lXYz9MHjvOxHzr/aUm4efpktbVOrF09rL/y4VHa8RMw==",
+      "version": "7.9.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.9.2.tgz",
+      "integrity": "sha512-pagqpVJnjZOfb+vIM23eTp7Sp/AAJjOgaowhP1f1TWOdk5/W8Uk8d/M/0wfleqx7SgjitjNPPsKeCZE1hTSp3w==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.9.1"
+        "react-router": "7.9.2"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -2690,6 +2691,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.8.tgz",
+      "integrity": "sha512-gyPKpIaxY9XcO2vSMrLbiER7QMAMGOQZVRdJ6Zi782jkbzZygq5GI9nG8g+sMgitRtndwaBSl7uiqC49o1SSiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-router-dom": "^7.9.1",
-    "slick-carousel": "^1.8.1"
+    "slick-carousel": "^1.8.1",
+    "zustand": "^5.0.8"
   },
   "devDependencies": {
     "@eslint/js": "^9.36.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,33 +2,32 @@ import NavbarGuest from "./components/NavbarGuest";
 import NavbarUser from "./components/NavbarUser";
 import Footer from "./components/Footer";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
-import { useState } from "react";
 import MainPage from "./pages/main/MainPage"; 
 import OrderPage from "./pages/order/OrderPage";
 import CartPage from "./pages/order/CartPage";
+import LoginPage from "./pages/auth/LoginPage";
+import CallbackPage from "./pages/auth/CallbackPage";
+import WithoutLayout from "./layouts/WithoutLayout";
+import WithLayout from "./layouts/WithLayout";
 
 function App() {
-  // 로그인 여부 (예시: 실제로는 context, recoil, redux, localStorage, cookie 등으로 관리)
-  const [isLoggedIn, setIsLoggedIn] = useState(true);
 
   return (
     <BrowserRouter>
-      {isLoggedIn ? <NavbarUser /> : <NavbarGuest />}
-
       <Routes>
-        {/* 메인 페이지 */}
-        <Route path="/main" element={<MainPage />} />
+        {/* Navbar 없는 그룹 */}
+        <Route element={<WithoutLayout />}>
+          <Route path="/login" element={<LoginPage />} />
+          <Route path="/callback" element={<CallbackPage />} />
+        </Route>
 
-        {/* shop 페이지 */}
-
-        {/* 주문 페이지 */}
-        <Route path="/order" element={<OrderPage />} />
-
-        {/* 장바구니 페이지 */}
-        <Route path="/cart" element={<CartPage />} />
+        {/* Navbar 있는 그룹 */}
+        <Route element={<WithLayout />}>
+          <Route path="/main" element={<MainPage />} />
+          <Route path="/order" element={<OrderPage />} />
+          <Route path="/cart" element={<CartPage />} />
+        </Route>
       </Routes>
-
-      <Footer />
     </BrowserRouter>
   );
 }

--- a/src/components/NavbarGuest.jsx
+++ b/src/components/NavbarGuest.jsx
@@ -1,4 +1,10 @@
+import { useNavigate } from "react-router-dom"
+
+
 export default function NavbarGuest(){
+
+    const navigate = useNavigate();
+
     return (
         <header>
         {/* <!-- Header Start --> */}
@@ -42,7 +48,7 @@ export default function NavbarGuest(){
                                 </ul>
                             </div>
 
-                            <div className="card-stor mint">Login</div>
+                            <div className="card-stor mint" onClick={()=> navigate("/login")}>Login</div>
                             <div className="card-stor purple">Regist</div>
                         </div>
                         {/* <!-- Mobile Menu --> */}

--- a/src/index.css
+++ b/src/index.css
@@ -24,8 +24,8 @@ a:hover {
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
+  /* display: flex;
+  place-items: center; */
   min-width: 320px;
   min-height: 100vh;
 }

--- a/src/layouts/WithLayout.jsx
+++ b/src/layouts/WithLayout.jsx
@@ -1,0 +1,18 @@
+import { Outlet } from "react-router-dom";
+import { useAuthStore } from "../store/auth";
+import NavbarUser from "../components/NavbarUser";
+import NavbarGuest from "../components/NavbarGuest";
+import Footer from "../components/Footer";
+
+export default function WithLayout(){
+    const { isLogin } = useAuthStore();
+    console.log("main페이지 진입! 로그인 여부=" + isLogin);
+
+    return (
+        <>
+            {isLogin ? <NavbarUser /> : <NavbarGuest />}
+            <Outlet />
+            <Footer />
+        </>
+    );
+}

--- a/src/layouts/WithoutLayout.jsx
+++ b/src/layouts/WithoutLayout.jsx
@@ -1,0 +1,17 @@
+import { Outlet } from "react-router-dom";
+
+export default function WithoutLayout(){
+    return (
+    <div
+      style={{
+        minHeight: "100vh",
+        width: "100%",
+        display: "flex",
+        alignItems: "center",      // 세로 중앙
+        justifyContent: "center",  // 가로 중앙
+      }}
+    >
+      <Outlet />
+    </div>
+  );
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -5,6 +5,6 @@ import App from './App.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+      <App />
   </StrictMode>,
 )

--- a/src/pages/auth/CallbackPage.jsx
+++ b/src/pages/auth/CallbackPage.jsx
@@ -1,0 +1,33 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { useAuthStore } from "../../store/auth";
+
+/* 
+백엔드에서 이 페이지로 강제 리다이렉트, 여기서 백엔드로부터 받은 JWT 토큰을 localStorage에 저장 
+작업을 마친 후 main 페이지로 이동
+ */
+export default function CallbackPage(){
+    const navigate = useNavigate();
+    
+    const { login } = useAuthStore();
+
+    useEffect(() => {
+        const params = new URLSearchParams(window.location.search);
+        console.log(params);
+        const token = params.get("accessToken");
+
+        if(token){
+            login(token);  //localStorage에 토큰 저장
+            window.history.replaceState({}, document.title, "/callback");  //주소창 정리     
+            
+            // 사용자 정보 API 호출해서 상태 갱신 가능
+            // fetch("/api/me", { headers: { Authorization: `Bearer ${token}`}})
+            //   .then(res => res.json())
+            //   .then(data => setUser(data));
+
+            navigate("/main");  // 메인 페이지로 이동
+        }
+
+    }, [navigate, setIsLogin]);  //함수 참조가 바뀌면 effect를 다시 실행, 훅에서 받아온 값들은 다 넣는 것을 권장 
+
+}

--- a/src/pages/auth/CallbackPage.jsx
+++ b/src/pages/auth/CallbackPage.jsx
@@ -28,6 +28,6 @@ export default function CallbackPage(){
             navigate("/main");  // 메인 페이지로 이동
         }
 
-    }, [navigate, setIsLogin]);  //함수 참조가 바뀌면 effect를 다시 실행, 훅에서 받아온 값들은 다 넣는 것을 권장 
+    }, [navigate, login]);  //함수 참조가 바뀌면 effect를 다시 실행, 훅에서 받아온 값들은 다 넣는 것을 권장 
 
 }

--- a/src/pages/auth/LoginPage.jsx
+++ b/src/pages/auth/LoginPage.jsx
@@ -1,0 +1,84 @@
+
+import React, { useEffect, useState } from "react";
+
+export default function LoginPage() {
+    const [id, setId] = useState("");
+    const [pwd, setPwd] = useState("");
+    const [error, setError] = useState("");
+
+    const handleSubmit = (e) => {
+        e.preventDefault();
+        // 로그인 처리 로직 (추후 구현)
+        alert(`ID: ${id}\nPWD: ${pwd}`);
+    };
+
+    const handleGoogleLogin = () => {
+        window.location.href = "http://localhost:7777/oauth2/authorization/google";
+    };
+
+
+    useEffect(() => {
+        const params = new URLSearchParams(location.search);
+        const errorMsg = params.get("error");
+        if (errorMsg) {
+            setError("구글 로그인에 실패했습니다. 다시 시도해주세요.");
+        } else {
+            setError("");
+        }
+    }, [location.search]);
+
+
+    return (
+        <div style={{ width: 380, maxWidth: "90vw", padding: 32, border: "1px solid #eee", borderRadius: 8, boxShadow: "0 2px 8px #eee" }}>
+            <div style={{ display: "flex", justifyContent: "center", marginBottom: 16 }}>
+                <img src="/assets/img/logo/mainLogo.png" alt="main logo" style={{ width: 120, height: 60, objectFit: "contain" }} />
+            </div>
+            
+            <h3 style={{ textAlign: "center", marginBottom: 24 }}>로그인/회원가입</h3>
+            {error && (
+                <div style={{ color: "#d32f2f", fontWeight: 500, textAlign: "center", marginBottom: 16 }}>
+                    {error}
+                </div>
+            )}
+            <form onSubmit={handleSubmit}>
+                <div style={{ marginBottom: 16 }}>
+                    <input
+                        type="text"
+                        placeholder="이메일"
+                        value={id}
+                        onChange={e => setId(e.target.value)}
+                        style={{ width: "100%", padding: 8, fontSize: 16 }}
+                        autoComplete="username"
+                    />
+                </div>
+                <div style={{ marginBottom: 24 }}>
+                    <input
+                        type="password"
+                        placeholder="비밀번호"
+                        value={pwd}
+                        onChange={e => setPwd(e.target.value)}
+                        style={{ width: "100%", padding: 8, fontSize: 16 }}
+                        autoComplete="current-password"
+                    />
+                </div>
+                <button type="submit" style={{ width: "100%", padding: 10, fontSize: 16, background: "#6e1ea0ff", color: "#fff", border: "none", borderRadius: 4, marginBottom: 8 }}>
+                    로그인
+                </button>
+                <div style={{ display: "flex", justifyContent: "flex-end", marginBottom: 20 }}>
+                    <span style={{ fontSize: 12, color: "#888" }}>
+                        아이디 찾기 | 비밀번호 찾기
+                    </span>
+                </div>
+            </form>
+            <button onClick={handleGoogleLogin} style={{ width: "100%", padding: 10, fontSize: 16, background: "#fff", color: "#222", border: "1px solid #ccc", borderRadius: 4, marginBottom: 16, display: "flex", alignItems: "center", justifyContent: "center", gap: 8 }}>
+                <img src="https://www.gstatic.com/firebasejs/ui/2.0.0/images/auth/google.svg" alt="Google logo" style={{ width: 20, height: 20, verticalAlign: "middle" }} />
+                Google 시작하기
+            </button>
+            <div style={{ width: "100%", display: "flex", justifyContent: "center", marginBottom: 8 }}>
+                <button style={{ width: "auto", minWidth: 100, padding: "4px 10px", fontSize: 13, background: "#fff", color: "#111", border: "1px solid #bbb", borderRadius: 4, fontWeight: 500 }}>
+                    이메일로 회원가입
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/src/store/auth.js
+++ b/src/store/auth.js
@@ -1,0 +1,17 @@
+//전역 상태 관리 - 로그인 관련
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+export const useAuthStore = create(
+    persist(
+        (set) => ({
+            accessToken: null,
+            isLogin: false,
+            login: (token) => set({ accessToken: token, isLogin: true}),
+            logout: () => set({ accessToken: null, isLogin: false }),
+        }),
+        {
+            name: "auth-storage"
+        }
+    )
+);

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,4 +4,12 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    port: 4444, // 기본 포트 변경
+    open: true,  // 브라우저 자동 실행 옵션 (원하면)
+    proxy: {
+      '/api':    { target: 'http://localhost:7777', changeOrigin: true },
+      '/images': { target: 'http://localhost:7777', changeOrigin: true },
+    },
+  }
 })


### PR DESCRIPTION
### 주요 사항
1. 전역 상태 관리 라이브러리 zustand 추가 
- zustand persist를 사용해서 accessToken을 localStorage에 저장함. 따라서 accessToken은 직접 localStorage.setItem()으로 저장하면 안되고 zustand를 통해서만 관리해야 함 

2. Navbar가 보이는 페이지와 안보이는 페이지 라우팅을 분리 
3. 일반 유저 로그인/회원가입은 한 페이지에서 처리 (현재 로그인 페이지에서 딱 구글 로그인 버튼만 동작하는 상태입니다)  


closes #1 