### PR TITLE
[fix] 회원가입 시 추가 정보 기입하는 페이지 추가, 로그인 완료 후 api호출로 유저 정보 전역으로 저장 

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,7 @@ import CallbackPage from "./pages/auth/CallbackPage";
 import WithoutLayout from "./layouts/WithoutLayout";
 import WithLayout from "./layouts/WithLayout";
 import ProtectedRoute from "./components/routes/ProtectedRoute";
+import OauthInfoPage from "./pages/auth/OauthInfoPage";
 
 function App() {
 
@@ -15,8 +16,10 @@ function App() {
       <Routes>
         {/* Navbar 없는 그룹 */}
         <Route element={<WithoutLayout />}>
+
           <Route path="/login" element={<LoginPage />} />
           <Route path="/callback" element={<CallbackPage />} />
+          <Route path="/oauth-join" element={<OauthInfoPage />} />
         </Route>
 
         {/* Navbar 있는 그룹 */}

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -1,12 +1,23 @@
 import axios from "axios";
 import { useAuthStore } from "../store/auth";
 
+
+/**
+ * accessToken을 담지 않는 요청  (회원가입, 로그인, 로그아웃 등)
+ */
+export const publicApi = axios.create({
+  baseURL: "http://localhost:7777/api",
+  withCredentials: true,
+});
+
+
+
 /**
  * axios 인스턴스 생성 파일 
  * 모든 API 요청에 공통으로 적용되는 규칙 관리 (baseURL, 헤더, 토큰담기, 에러 처리 등)
  */
 
-const api = axios.create({
+export const api = axios.create({
     baseURL: "http://localhost:7777/api",   //후에 gateway 주소로 변경 
     withCredentials: true,   // axios의 기본 동작은 쿠키나 인증정보를 자동으로 안보냄. 쿠키에 들은 refreshToken을 보내기 위해 옵션 설정 
 });
@@ -52,4 +63,4 @@ api.interceptors.response.use(
     }
 )
 
-export default api;
+

--- a/src/components/NavbarUser.jsx
+++ b/src/components/NavbarUser.jsx
@@ -8,7 +8,7 @@ export default function NavbarUser(){
 
     const logout = async () => {
         try{
-            const res = await api.post("/auth/logout", {}, { withCredentials: true });
+            const res = await api.post("/auth/logout", {}, { withCredentials: true });  // 쿠키는 보내야되니께 ㅋ 
             
             logoutAction();
             navigate("/main");

--- a/src/components/NavbarUser.jsx
+++ b/src/components/NavbarUser.jsx
@@ -1,6 +1,7 @@
 import { useNavigate } from "react-router-dom"
-import api from "../api/api"
+
 import { useAuthStore } from "../store/auth"
+import { publicApi } from "../api/api";
 
 export default function NavbarUser(){
     const navigate = useNavigate();
@@ -8,7 +9,7 @@ export default function NavbarUser(){
 
     const logout = async () => {
         try{
-            const res = await api.post("/auth/logout", {}, { withCredentials: true });  // 쿠키는 보내야되니께 ㅋ 
+            const res = await publicApi.post("/auth/logout");  // 쿠키는 보내야되니께 ㅋ 
             
             logoutAction();
             navigate("/main");

--- a/src/components/NavbarUser.jsx
+++ b/src/components/NavbarUser.jsx
@@ -8,7 +8,7 @@ export default function NavbarUser(){
 
     const logout = async () => {
         try{
-            const res = await api.post("/auth/logout")
+            const res = await api.post("/auth/logout", {}, { withCredentials: true });
             
             logoutAction();
             navigate("/main");

--- a/src/pages/auth/CallbackPage.jsx
+++ b/src/pages/auth/CallbackPage.jsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAuthStore } from "../../store/auth";
+import { api } from "../../api/api";
 
 /* 
 백엔드에서 이 페이지로 강제 리다이렉트, 여기서 백엔드로부터 받은 JWT 토큰을 localStorage에 저장 
@@ -9,25 +10,43 @@ import { useAuthStore } from "../../store/auth";
 export default function CallbackPage(){
     const navigate = useNavigate();
     
-    const { login } = useAuthStore();
+    const { login, setUser } = useAuthStore.getState();
 
     useEffect(() => {
-        const params = new URLSearchParams(window.location.search);
-        console.log(params);
-        const token = params.get("accessToken");
+        const fetchUser = async() => {
+            const params = new URLSearchParams(window.location.search);
+            console.log(params);
+            const token = params.get("accessToken");
 
-        if(token){
-            login(token);  //localStorage에 토큰 저장
-            window.history.replaceState({}, document.title, "/callback");  //주소창 정리     
+            if(token){
+                login(token);  //localStorage에 토큰 저장
             
-            // 사용자 정보 API 호출해서 상태 갱신 가능
-            // fetch("/api/me", { headers: { Authorization: `Bearer ${token}`}})
-            //   .then(res => res.json())
-            //   .then(data => setUser(data));
+                try{
+                    // 인증 성공한 유저의 정보를 가져와서 전역으로 저장 
+                    const res = await api.get("/user/me");
+                    const user = res.data.data;
+                    setUser(user);
+                    console.log(user);
+        
+                    window.history.replaceState({}, document.title, "/callback");  //주소창 정리     
+                } catch(err){
+                    console.log("api(/api/user/me) 호출 실패");
+                }
+            
 
-            navigate("/main");  // 메인 페이지로 이동
-        }
+                // 사용자 정보 API 호출해서 상태 갱신 가능
+                // fetch("/api/me", { headers: { Authorization: `Bearer ${token}`}})
+                //   .then(res => res.json())
+                //   .then(data => setUser(data));
 
-    }, [navigate, login]);  //함수 참조가 바뀌면 effect를 다시 실행, 훅에서 받아온 값들은 다 넣는 것을 권장 
+                
+
+                navigate("/main");  // 메인 페이지로 이동
+            }
+        };
+
+        fetchUser();
+
+    }, [navigate, login, setUser]);  //함수 참조가 바뀌면 effect를 다시 실행, 훅에서 받아온 값들은 다 넣는 것을 권장 
 
 }

--- a/src/pages/auth/OauthInfoPage.jsx
+++ b/src/pages/auth/OauthInfoPage.jsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
-import api from "../../api/api";
+import { publicApi } from "../../api/api";
 import { useAuthStore } from "../../store/auth";
 
 export default function OauthInfoPage() {
@@ -19,7 +19,7 @@ export default function OauthInfoPage() {
     const handleSubmit = async (e) => {
     
         try{
-            const res = await api.post("/auth/oauth2/join", {
+            const res = await publicApi.post("/auth/oauth2/join", {
                 provider, 
                 oauthId,
                 nickname

--- a/src/pages/auth/OauthInfoPage.jsx
+++ b/src/pages/auth/OauthInfoPage.jsx
@@ -1,0 +1,64 @@
+import { useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import api from "../../api/api";
+import { useAuthStore } from "../../store/auth";
+
+export default function OauthInfoPage() {
+
+    
+    const navigate = useNavigate();
+    const login = useAuthStore((state) => state.login);
+    const location = useLocation();
+    const params = new URLSearchParams(location.search);
+    const provider = params.get("provider");
+    const oauthId = params.get("oauthId");
+
+    const [nickname, setNickname] = useState("");
+  
+
+    const handleSubmit = async (e) => {
+    
+        try{
+            const res = await api.post("/auth/oauth2/join", {
+                provider, 
+                oauthId,
+                nickname
+            });
+
+            const accessToken = res.data.data.accessToken;
+
+            login(accessToken);
+            navigate("/main");
+            
+
+        } catch(err){
+            console.log(err);
+        }
+    };
+
+  return (
+    <div style={{ width: 380, maxWidth: "90vw", margin: "80px auto", padding: 32, border: "1px solid #eee", borderRadius: 8, boxShadow: "0 2px 8px #eee" }}>
+        <div style={{ display: "flex", justifyContent: "center", marginBottom: 16 }}>
+            <img src="/assets/img/logo/mainLogo.png" alt="main logo" style={{ width: 120, height: 60, objectFit: "contain" }} />
+        </div>
+      <h3 style={{ textAlign: "center", marginBottom: 24 }}>추가정보 입력</h3>
+      <form onSubmit={handleSubmit}>
+        <label htmlFor="nickname" style={{ fontWeight: 500, fontSize: 14, color: "#424242ff"}}>
+          다른 유저와 겹치지 않는 닉네임을 입력해주세요
+        </label>
+        <input
+          id="nickname"
+          type="text"
+          placeholder="닉네임 (2~20자)"
+          value={nickname}
+          onChange={e => setNickname(e.target.value)}
+          style={{ width: "100%", padding: 10, fontSize: 16, borderRadius: 4, border: '1px solid #ccc', marginBottom: 24 }}
+          autoComplete="off"
+        />
+        <button type="button" onClick={handleSubmit} style={{ width: "100%", padding: 12, fontSize: 16, background: "#6e1ea0ff", color: "#fff", border: "none", borderRadius: 4, fontWeight: 500, marginTop: 12 }}>
+          동의하고 가입하기
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/src/store/auth.js
+++ b/src/store/auth.js
@@ -7,8 +7,10 @@ export const useAuthStore = create(
         (set) => ({
             accessToken: null,
             isLogin: false,
+            user: null,
             login: (token) => set({ accessToken: token, isLogin: true}),
             logout: () => set({ accessToken: null, isLogin: false }),
+            setUser: (user) => set({ user }), 
         }),
         {
             name: "auth-storage"


### PR DESCRIPTION
### 변경 사항
- axios 객체인 api를 `api`(accessToken 담은 요청)와 `publicApi`(accessToken을 담지 않는 요청)로 분리 
- 로그인 하면 유저 정보(pk, 닉네임, 이메일, 권한명)는 전역으로 저장되기 때문에 api 호출할 필요 없이 가져다 사용하면 됨 

매우 간단한 사용법 (`/src/store/auth.js` 에 전역 상태 관리 코드 있으니 참고하세요)
```
const { user } = useAuthStore();

//user.email
//user.id 
```
