### PR TITLE
[chore] .env 파일로 서버 주소 관리

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -6,7 +6,7 @@ import { useAuthStore } from "../store/auth";
  * accessToken을 담지 않는 요청  (회원가입, 로그인, 로그아웃 등)
  */
 export const publicApi = axios.create({
-  baseURL: "http://localhost:7777/api",
+  baseURL: `${import.meta.env.VITE_API_URL}/api`,
   withCredentials: true,
 });
 
@@ -18,7 +18,7 @@ export const publicApi = axios.create({
  */
 
 export const api = axios.create({
-    baseURL: "http://localhost:7777/api",   //후에 gateway 주소로 변경 
+    baseURL: `${import.meta.env.VITE_API_URL}/api`,   //후에 gateway 주소로 변경 
     withCredentials: true,   // axios의 기본 동작은 쿠키나 인증정보를 자동으로 안보냄. 쿠키에 들은 refreshToken을 보내기 위해 옵션 설정 
 });
 

--- a/src/pages/auth/LoginPage.jsx
+++ b/src/pages/auth/LoginPage.jsx
@@ -13,7 +13,7 @@ export default function LoginPage() {
     };
 
     const handleGoogleLogin = () => {
-        window.location.href = "http://localhost:7777/oauth2/authorization/google";
+        window.location.href = `${import.meta.env.VITE_API_URL}/oauth2/authorization/google`;
     };
 
 

--- a/src/pages/live/LivePage.jsx
+++ b/src/pages/live/LivePage.jsx
@@ -8,7 +8,7 @@ import toast, { Toaster } from 'react-hot-toast';
 import { useAuthStore } from '../../store/auth';
 
 // ===== 서버 엔드포인트 =====
-const SERVER_URL  = 'http://192.168.60.30:4000'; // mediasoup signaling
+const SERVER_URL  = '/socket.io'; // mediasoup signaling
 const CHAT_WS_URL = '/ws';                       // Vite proxy → chat-server:8888
 
 // artistId 기반 토픽

--- a/src/pages/live/Viewer 병합본(테스트안함) copy.jsx
+++ b/src/pages/live/Viewer 병합본(테스트안함) copy.jsx
@@ -6,8 +6,8 @@ import SubtitleDisplay from '../../components/subtitle/SubtitleDisplay';
 import SockJS from 'sockjs-client';
 import { Client as StompClient } from '@stomp/stompjs';
 
-const SUBTITLE_API_URL = 'http://localhost:8080'; // 자막 처리 서버
-const SERVER_URL = 'http://192.168.56.1:4000';
+const SUBTITLE_API_URL = import.meta.env.VITE_LIVE_URL; // 자막 처리 서버
+const SERVER_URL = import.meta.env.VITE_MEDIASOUP_HOST;
 const CHAT_WS_URL = '/ws';                       // Vite proxy → chat-server:8888
 
 // artistId 기반 토픽

--- a/src/pages/live/Viewer.jsx
+++ b/src/pages/live/Viewer.jsx
@@ -13,10 +13,10 @@ import { getStreamProductsByStream } from "../../utils/StreamProductApi";
 import { getProduct } from "../../utils/ProductApi";
 import { getPromotion } from "../../utils/PromotionApi";
 
-const SUBTITLE_API_URL = 'http://localhost:8080';
-const SERVER_URL = 'http://172.20.10.10:4000';
+const SUBTITLE_API_URL = import.meta.env.VITE_LIVE_URL;
+const SERVER_URL = import.meta.env.VITE_MEDIASOUP_HOST;
 const CHAT_WS_URL = import.meta.env.VITE_CHAT_WS_URL || '/ws';
-const STOMP_BROKER_URL = import.meta.env.VITE_STOMP_BROKER_URL || 'ws://localhost:8888/ws';
+const STOMP_BROKER_URL = import.meta.env.VITE_STOMP_BROKER_URL || `${import.meta.env.VITE_WS_URL}/ws`;
 const TOPIC_SUBSCRIBE = (id) => `/topic/public/${id ?? 'global'}`;
 const APP_SEND = (id) => `/app/live/${id ?? 'global'}`;
 
@@ -441,7 +441,7 @@ const Viewer = () => {
           }}>
             <div style={{ flex: '0 0 200px' }}>
               <img
-                src={promotion.img ? `http://localhost:7777${promotion.img}` : 'https://via.placeholder.com/200x200?text=No+Image'}
+                src={promotion.img ? `${import.meta.env.VITE_API_URL}${promotion.img}` : 'https://via.placeholder.com/200x200?text=No+Image'}
                 alt={promotion.name}
                 style={{
                   width: '100%', height: '200px', borderRadius: '10px', objectFit: 'cover',
@@ -490,7 +490,7 @@ const Viewer = () => {
           {productDetails.length > 0 ? productDetails.map((p) => (
             <div key={p.id} className="live-page-product-card live-page-product-card-wide">
               <img
-                src={p.img ? `http://localhost:7777${p.img}` : '/assets/img/placeholder/240.png'}
+                src={p.img ? `${import.meta.env.VITE_API_URL}${p.img}` : '/assets/img/placeholder/240.png'}
                 alt={p.name}
                 className="live-page-product-img"
               />

--- a/src/utils/ArtistApi.jsx
+++ b/src/utils/ArtistApi.jsx
@@ -1,7 +1,7 @@
 import axios from "axios";
 
 // 아티스트 관련 공통 URL (판매자와 요청하는 목록이 같아서 ent로 요청)
-const URL = "http://localhost:7777/api/ent/artists";
+const URL = `${import.meta.env.VITE_API_URL}/api/ent/artists`;
 
 // 아티스트 목록 (판매자와 요청하는 목록이 같아서 ent로 요청)
 export const getArtists = () => axios.get(URL);

--- a/src/utils/MembershipApi.jsx
+++ b/src/utils/MembershipApi.jsx
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-const URL = "http://localhost:7777/api/memberships";
+const URL = `${import.meta.env.VITE_API_URL}/api/memberships`;
 
 // 멤버십 목록 조회
 export const getMembership = (userId) => axios.get(`${URL}/${userId}`);

--- a/src/utils/OrderApi.jsx
+++ b/src/utils/OrderApi.jsx
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-const URL = "http://localhost:7777/api/orders";
+const URL = `${import.meta.env.VITE_API_URL}/api/orders`;
 
 // 주문서 보내기
 export const submitOrder = (data) => axios.post(`${URL}`, data);

--- a/src/utils/ProductApi.jsx
+++ b/src/utils/ProductApi.jsx
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-const BASE_URL = "http://localhost:7777/api";
+const BASE_URL = `${import.meta.env.VITE_API_URL}/api`;
 axios.defaults.baseURL = "/api"; // 프록시
 
 export const getProductDetail = (id) => axios.get(`/ent/products/${id}`);

--- a/src/utils/PromotionApi.jsx
+++ b/src/utils/PromotionApi.jsx
@@ -1,7 +1,7 @@
 // utils/PromotionApi.jsx
 import axios from "axios";
 
-const BASE_URL = "http://localhost:7777/api/ent";
+const BASE_URL = `${import.meta.env.VITE_API_URL}/api/ent`;
 
 // 아티스트별 프로모션 조회
 export const getPromotionsByArtist = (artistId) => {

--- a/src/utils/StreamApi.jsx
+++ b/src/utils/StreamApi.jsx
@@ -1,7 +1,7 @@
 import axios from "axios";
 
 // 라이브 관련 공통 URL
-const URL = "http://localhost:7777/api/ent/streams";
+const URL = `${import.meta.env.VITE_API_URL}/api/ent/streams`;
 
 // 라이브 목록
 export const getStreams = () => axios.get(URL);

--- a/src/utils/StreamProductApi.jsx
+++ b/src/utils/StreamProductApi.jsx
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-const URL = "http://localhost:7777/api/ent/stream-products"; // 필요 시 환경변수로 분리
+const URL = `${import.meta.env.VITE_API_URL}/api/ent/stream-products`;
 
 // 전체 조회
 export const getStreamProducts = async () => {

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,22 +1,30 @@
-// Universe_React_User/vite.config.js
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 
-export default defineConfig({
-  plugins: [react()],
-  server: {
-    port: 4444,
-    open: true,
-    proxy: {
-      // Spring REST
-      '/api': { target: 'http://localhost:7777', changeOrigin: true },
-      '/images': { target: 'http://localhost:7777', changeOrigin: true },
-      '/ws':     { target: 'http://localhost:8888', changeOrigin: true, ws: true }, // Chat 서버
-      '/chatapi':     { target: 'http://localhost:8888', changeOrigin: true}, // Chat 서버 API
+export default ({ mode }) => {
+  // Load env file based on `mode` in the current working directory.
+  // Set the third parameter to '' to load all env regardless of the `VITE_` prefix.
+  const env = loadEnv(mode, process.cwd(), '');
+  return defineConfig({
+    plugins: [react()],
+    server: {
+      port: 4444,
+      open: true,
+      proxy: {
+        // Spring REST
+        '/api': { target: env.VITE_API_URL, changeOrigin: true },
+        '/images': { target: env.VITE_API_URL, changeOrigin: true },
+        '/ws': { target: env.VITE_CHAT_URL, changeOrigin: true, ws: true }, // Chat 서버
+        '/chatapi': { target: env.VITE_CHAT_URL, changeOrigin: true }, // Chat 서버 API
 
-      // mediasoup socket.io
-      '/socket.io': { target: 'http://172.20.10.10:4000', changeOrigin: true, ws: true },
+        // mediasoup socket.io
+        '/socket.io': {
+          target: env.VITE_MEDIASOUP_HOST,
+          changeOrigin: true,
+          ws: true,
+        },
+      },
     },
-  },
-  define: { global: 'window' },
-});
+    define: { global: 'window' },
+  });
+};


### PR DESCRIPTION
### 변경사항

- 하드코딩된 서버 주소를 .env파일로 관리 
- 로컬 개발 용도: `.env.development`, 배포 용도: `.env.production` 
- 파일은 프로젝트 루트에 위치하고 로컬 용도 파일은 notion에 올려뒀습니다

- mediasoup, live 관련 서버 주소가 여러개로 돼있어서 우선 하나로 합쳤는데 틀린 부분 있으면 알려주세요! 